### PR TITLE
Wait until connected to network before starting discovery service

### DIFF
--- a/src/ravelights/core/ravelights_app.py
+++ b/src/ravelights/core/ravelights_app.py
@@ -16,7 +16,7 @@ from ravelights.interface.data_router import (
     DataRouterVisualizer,
     DataRouterWebsocket,
 )
-from ravelights.interface.discovery import discovery_service
+from ravelights.interface.discovery import connectivity_check, discovery_service
 from ravelights.interface.rest_api import RestAPI
 
 
@@ -53,6 +53,7 @@ class RaveLightsApp:
         self.use_visualizer = use_visualizer
         self.print_stats = print_stats
 
+        connectivity_check.wait_until_connected_to_network()
         discovery_service.start()
 
         if run:

--- a/src/ravelights/interface/discovery/connectivity_check.py
+++ b/src/ravelights/interface/discovery/connectivity_check.py
@@ -1,0 +1,26 @@
+import socket
+import time
+
+from loguru import logger
+
+
+def is_connected_to_network() -> bool:
+    s = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM)
+    s.settimeout(0)
+
+    try:
+        s.connect(("10.254.254.254", 1))  # Any IP address works
+        return True
+    except socket.error:
+        return False
+    finally:
+        s.close()
+
+
+def wait_until_connected_to_network() -> None:
+    logger.info("Waiting until connected to network...")
+
+    while not is_connected_to_network():
+        time.sleep(5)
+
+    logger.info("Successfully connected to network")

--- a/src/ravelights/interface/discovery/discovery_service.py
+++ b/src/ravelights/interface/discovery/discovery_service.py
@@ -1,5 +1,6 @@
 from loguru import logger
 from ravelights.core.custom_typing import DiscoveryUpdateCallback
+from ravelights.interface.discovery import connectivity_check
 from ravelights.interface.discovery.pixeldriver_service_listener import PixeldriverServiceListener
 from zeroconf import ServiceBrowser, Zeroconf
 
@@ -36,6 +37,9 @@ def start() -> None:
     """
 
     global _zeroconf, _service_browser
+
+    if not connectivity_check.is_connected_to_network():
+        raise RuntimeError("Host must be connected to network before discovery service can be started")
 
     if _zeroconf is not None and _service_browser is not None:
         logger.warning("Discovery service already running. Stopping first before starting again...")


### PR DESCRIPTION
If the discovery service is started before being connected to a network, mDNS device discovery does not work properly.